### PR TITLE
Add Dry::Core::Extensions

### DIFF
--- a/lib/dry/core/extensions.rb
+++ b/lib/dry/core/extensions.rb
@@ -1,0 +1,29 @@
+require 'set'
+
+module Dry
+  module Core
+    module Extensions
+      def self.extended(obj)
+        super
+        obj.instance_variable_set(:@__available_extensions__, {})
+        obj.instance_variable_set(:@__loaded_extensions__, Set.new)
+      end
+
+      def register_extension(name, &block)
+        @__available_extensions__[name] = block
+      end
+
+      def load_extensions(*extensions)
+        extensions.each do |ext|
+          block = @__available_extensions__.fetch(ext) do
+            raise ArgumentError, "Unknown extension: #{ext.inspect}"
+          end
+          unless @__loaded_extensions__.include?(ext)
+            block.call
+            @__loaded_extensions__ << ext
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dry/core/extensions_spec.rb
+++ b/spec/dry/core/extensions_spec.rb
@@ -1,0 +1,32 @@
+require 'dry/core/extensions'
+
+RSpec.describe Dry::Core::Extensions do
+  subject do
+    Class.new do
+      extend Dry::Core::Extensions
+    end
+  end
+
+  it 'allows to register and load extensions' do
+    foo = false
+    bar = false
+
+    subject.register_extension(:foo) { foo = true }
+    subject.register_extension(:bar) { bar = true }
+
+    subject.load_extensions(:foo, :bar)
+
+    expect(foo).to be true
+    expect(bar).to be true
+  end
+
+  it 'swallows double loading' do
+    cnt = 0
+
+    subject.register_extension(:foo) { cnt += 1 }
+    subject.load_extensions(:foo)
+    subject.load_extensions(:foo)
+
+    expect(cnt).to be 1
+  end
+end


### PR DESCRIPTION
A simple mixin for registering and loading arbitrary extension blocks.