### PR TITLE
Add Dry::Core::ClassBuilder

### DIFF
--- a/lib/dry/core/class_builder.rb
+++ b/lib/dry/core/class_builder.rb
@@ -26,7 +26,6 @@ module Dry
         klass.singleton_class.class_eval do
           define_method(:name) { name }
           alias_method :inspect, :name
-          alias_method :to_str, :name
           alias_method :to_s, :name
         end
 

--- a/lib/dry/core/class_builder.rb
+++ b/lib/dry/core/class_builder.rb
@@ -1,0 +1,39 @@
+module Dry
+  module Core
+    # Class for generating more classes
+    class ClassBuilder
+      attr_reader :name
+      attr_reader :parent
+
+      def initialize(name: , parent: Object)
+        @name = name
+        @parent = parent
+      end
+
+      # Generate a class based on options
+      #
+      # @example
+      #   builder = Dry::Core::ClassBuilder.new(name: 'MyClass')
+      #
+      #   klass = builder.call
+      #   klass.name # => "MyClass"
+      #
+      # @return [Class]
+      def call
+        klass = Class.new(parent)
+        name = self.name
+
+        klass.singleton_class.class_eval do
+          define_method(:name) { name }
+          alias_method :inspect, :name
+          alias_method :to_str, :name
+          alias_method :to_s, :name
+        end
+
+        yield(klass) if block_given?
+
+        klass
+      end
+    end
+  end
+end

--- a/spec/dry/core/class_builder_spec.rb
+++ b/spec/dry/core/class_builder_spec.rb
@@ -1,0 +1,42 @@
+require 'dry/core/class_builder'
+
+RSpec.describe Dry::Core::ClassBuilder do
+  subject(:builder) { described_class.new(options) }
+
+  let(:klass) { builder.call }
+
+  describe '#call' do
+    let(:options) do
+      { name: 'Test', parent: parent }
+    end
+
+    let(:parent) { Class.new }
+
+    it 'returns a class constant' do
+      expect(klass).to be_instance_of(Class)
+    end
+
+    it 'sets class name based on provided :name option' do
+      expect(klass.name).to eql(options[:name])
+    end
+
+    it 'uses a parent class provided by :parent option' do
+      expect(klass).to be < parent
+    end
+
+    it 'defines to_s and inspect' do
+      expect(klass.to_s).to eql(options[:name])
+      expect(klass.inspect).to eql(options[:name])
+    end
+
+    it 'yields created class' do
+      klass = builder.call { |yielded_class|
+        yielded_class.class_eval do
+          def self.testing; end
+        end
+      }
+
+      expect(klass).to respond_to(:testing)
+    end
+  end
+end


### PR DESCRIPTION
It's another port from rom-support, but I haven't implemented `Options` here. I'm going to have a closer look at using dry-initializer in rom, as far as I can tell, this suits as a `ROM::Options` replacement quite well. I've made some benchmarks today, it's faster than than ROM::Options by 20% or so. Also dry-t may require [some tweaks](https://github.com/dry-rb/dry-types/issues/123) to make type-checking more flexible