### PR TITLE
Fix require in dry-core.rb

### DIFF
--- a/lib/dry-core.rb
+++ b/lib/dry-core.rb
@@ -1,1 +1,1 @@
-require 'dry-core'
+require 'dry/core'


### PR DESCRIPTION
`dry-core.rb` should require `dry/core` instead of itself