### PR TITLE
s/dry-code/dry-core/

### DIFF
--- a/dry-core.gemspec
+++ b/dry-core.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'A toolset of small support modules used throughout the dry-rb ecosystem.'
   spec.description   = spec.summary
-  spec.homepage      = 'https://github.com/dry-rb/dry-code'
+  spec.homepage      = 'https://github.com/dry-rb/dry-core'
   spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
Fixes `spec.homepage` that points to a non-existing repo.