### PR TITLE
Typo fix (grammar): Remove "Allows to" prefix.

### DIFF
--- a/lib/dry/core/extensions.rb
+++ b/lib/dry/core/extensions.rb
@@ -2,7 +2,7 @@ require 'set'
 
 module Dry
   module Core
-    # Allows to define extensions that can be later enabled by the user.
+    # Define extensions that can be later enabled by the user.
     #
     # @example
     #


### PR DESCRIPTION
I can further edit this if you prefer, but this version seems succinct.