### PR TITLE
Add type option to class attribute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   else
     gem 'activesupport', '~> 4.2'
   end
-
   gem 'inflecto', '~> 0.0', '>= 0.0.2'
   gem 'codeclimate-test-reporter', require: false
   gem 'simplecov', require: false

--- a/dry-core.gemspec
+++ b/dry-core.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'dry-types', '~> 0.9', '>= 0.9.0'
 end

--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -24,7 +24,7 @@ module Dry
       #   class MyClass
       #     extend Dry::Core::ClassAttributes
       #
-      #     defines :one, :two, type: Dry::Types::Int
+      #     defines :one, :two, type: Dry::Types['strict.int']
       #
       #     one 1
       #     two 2
@@ -39,7 +39,7 @@ module Dry
       #
       #   OtherClass.one # => 1
       #   OtherClass.two # => 3
-      def defines(*args, type: Dry::Types::Any)
+      def defines(*args, type: Dry::Types['any'])
         mod = Module.new do
           args.each do |name|
             define_method(name) do |value = Undefined|

--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -1,4 +1,6 @@
 require 'dry/core/constants'
+require 'dry/core/errors'
+require 'dry-types'
 
 module Dry
   module Core
@@ -11,25 +13,33 @@ module Dry
       # Specify what attributes a class will use
       #
       # @example
+      #  class ExtraClass
+      #    extend Dry::Core::ClassAttributes
+      #
+      #    defines :hello
+      #
+      #    hello 'world'
+      #  end
+      #
       #   class MyClass
       #     extend Dry::Core::ClassAttributes
       #
-      #     defines :one, :two
+      #     defines :one, :two, type: Dry::Types::Int
       #
       #     one 1
       #     two 2
       #   end
       #
       #   class OtherClass < MyClass
-      #     two 'two'
+      #     two 3
       #   end
       #
       #   MyClass.one # => 1
       #   MyClass.two # => 2
       #
       #   OtherClass.one # => 1
-      #   OtherClass.two # => 'two'
-      def defines(*args)
+      #   OtherClass.two # => 3
+      def defines(*args, type: Dry::Types::Any)
         mod = Module.new do
           args.each do |name|
             define_method(name) do |value = Undefined|
@@ -42,6 +52,8 @@ module Dry
                   nil
                 end
               else
+                raise InvalidClassAttributeValue unless type.valid?(value)
+
                 instance_variable_set(ivar, value)
               end
             end

--- a/lib/dry/core/errors.rb
+++ b/lib/dry/core/errors.rb
@@ -1,0 +1,5 @@
+module Dry
+  module Core
+    InvalidClassAttributeValue = Class.new(StandardError)
+  end
+end

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -1,48 +1,82 @@
 require 'dry/core/class_attributes'
+require 'dry-types'
 
 RSpec.describe 'Class Macros' do
-  class MyClass
-    extend Dry::Core::ClassAttributes
+  before do
+    module Test
+      class MyClass
+        extend Dry::Core::ClassAttributes
 
-    defines :one, :two, :three
+        defines :one, :two, :three
 
-    one 1
-    two 2
-    three 3
-  end
+        one 1
+        two 2
+        three 3
+      end
 
-  class OtherClass < MyClass
-    two 'two'
-    three nil
-  end
-
-  after(:all) do
-    %i(MyClass OtherClass).each { |k| Object.send(:remove_const, k) }
+      class OtherClass < Test::MyClass
+        two 'two'
+        three nil
+      end
+    end
   end
 
   it 'defines accessor like methods on the class and subclasses' do
     %i(one two three).each do |method_name|
-      expect(MyClass).to respond_to(method_name)
-      expect(OtherClass).to respond_to(method_name)
+      expect(Test::MyClass).to respond_to(method_name)
+      expect(Test::OtherClass).to respond_to(method_name)
     end
   end
 
   it 'allows storage of values on the class' do
-    expect(MyClass.one).to eq(1)
-    expect(MyClass.two).to eq(2)
-    expect(MyClass.three).to eq(3)
+    expect(Test::MyClass.one).to eq(1)
+    expect(Test::MyClass.two).to eq(2)
+    expect(Test::MyClass.three).to eq(3)
   end
 
   it 'allows overwriting of inherited values with nil' do
-    expect(OtherClass.three).to eq(nil)
+    expect(Test::OtherClass.three).to eq(nil)
+  end
+
+  context 'type option' do
+    before do
+      module Test
+        class Types
+          include Dry::Types.module
+        end
+
+        class NewClass
+          extend Dry::Core::ClassAttributes
+
+          defines :one, type: Test::Types::String
+
+          one '1'
+        end
+      end
+    end
+    it 'allows to pass type option' do
+      expect(Test::NewClass.one).to eq '1'
+    end
+
+    it 'raises InvalidClassAttributeValue when invalid value is pass' do
+      expect{
+        class InvalidNewClass
+          extend Dry::Core::ClassAttributes
+
+          defines :one, type: Test::Types::String
+
+          one 1
+        end
+      }.to raise_error(Dry::Core::InvalidClassAttributeValue)
+    end
   end
 
   it 'allows inheritance of values' do
-    expect(OtherClass.one).to eq(1)
+    expect(Test::OtherClass.one).to eq(1)
   end
 
   it 'allows overwriting of inherited values' do
-    expect(OtherClass.two).to eq('two')
+    expect(Test::OtherClass.two).to eq('two')
   end
 
   it 'copies values from the parent before running hooks' do


### PR DESCRIPTION
@solnic @flash-gordon 

Add `type` option for defining class attributes 

### Example

```ruby
class NewClass
  extend Dry::Core::ClassAttributes

  defines :one, type: Test::Types::String
  one '1'
end
```

This is interesting because we can use to control for invalid value passed to class attributes like in dry-struct defining `constructor_type`

```ruby
defines :constructor_type, type: Dry::Types['strict.symbol'].enum(:foo, :bar)
```