### PR TITLE
Add Undefined.default

### DIFF
--- a/lib/dry/core/constants.rb
+++ b/lib/dry/core/constants.rb
@@ -43,6 +43,26 @@ module Dry
         def undefined.inspect
           'Undefined'
         end
+
+        # Pick a value, if the first argument is not Undefined, return it back,
+        # otherwise return the second arg or yield the block.
+        #
+        # @example
+        #  def method(val = Undefined)
+        #    1 + Undefined.default(val, 2)
+        #  end
+        #
+        def undefined.default(x, y = self)
+          if x.equal?(self)
+            if y.equal?(self)
+              yield
+            else
+              y
+            end
+          else
+            x
+          end
+        end
       end.freeze
 
       def self.included(base)

--- a/spec/dry/core/constants_spec.rb
+++ b/spec/dry/core/constants_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe Dry::Core::Constants do
     expect(subject.empty_opts).to eql({})
 
     expect(subject.undefined).to be Dry::Core::Constants::Undefined
-    expect(subject.undefined.to_s).to eql('Undefined')
-    expect(subject.undefined.inspect).to eql('Undefined')
   end
 
   describe 'nested' do
@@ -73,6 +71,36 @@ RSpec.describe Dry::Core::Constants do
 
     example 'constants available in lexical scope' do
       expect(subject.empty_array).to be Dry::Core::Constants::EMPTY_ARRAY
+    end
+  end
+
+  describe 'Undefined' do
+    subject { Dry::Core::Constants::Undefined }
+
+    describe '.inspect' do
+      it 'returns "Undefined"' do
+        expect(subject.inspect).to eql('Undefined')
+      end
+    end
+
+    describe '.to_s' do
+      it 'returns "Undefined"' do
+        expect(subject.to_s).to eql('Undefined')
+      end
+    end
+
+    describe '.default' do
+      it "returns the first arg if it's not Undefined" do
+        expect(subject.default(:first, :second)).to eql(:first)
+      end
+
+      it 'returns the second arg if the first one is Undefined' do
+        expect(subject.default(subject, :second)).to eql(:second)
+      end
+
+      it 'yields a block' do
+        expect(subject.default(subject) { :second }).to eql(:second)
+      end
     end
   end
 end


### PR DESCRIPTION
This adds `Undefined.default` that can be useful for compacting `Undefined`-affected branching:

```ruby
def apply(val = Undefined, &block)
  arg = Undefined.default(val, &block)
  Curry.(@value).(arg)
end
```