### PR TITLE
Add Memoizable from ROM

### DIFF
--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -4,7 +4,6 @@ module Dry
       MEMOIZED_HASH = {}.freeze
 
       module ClassInterface
-        # @api private
         def memoize(*names)
           prepend(Memoizer.new(self, names))
         end

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -1,7 +1,7 @@
 module Dry
   module Core
     module Memoizable
-      MEMOIZED_HASH = {}
+      MEMOIZED_HASH = {}.freeze
 
       module ClassInterface
         # @api private

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -1,0 +1,59 @@
+module Dry
+  module Core
+    module Memoizable
+      MEMOIZED_HASH = {}
+
+      module ClassInterface
+        # @api private
+        def memoize(*names)
+          prepend(Memoizer.new(self, names))
+        end
+
+        def new(*)
+          obj = super
+          obj.instance_variable_set(:'@__memoized__', MEMOIZED_HASH.dup)
+          obj
+        end
+      end
+
+      def self.included(klass)
+        super
+        klass.extend(ClassInterface)
+      end
+
+      attr_reader :__memoized__
+
+      # @api private
+      class Memoizer < Module
+        attr_reader :klass
+        attr_reader :names
+
+        # @api private
+        def initialize(klass, names)
+          @names = names
+          @klass = klass
+          define_memoizable_names!
+        end
+
+        private
+
+        # @api private
+        def define_memoizable_names!
+          names.each do |name|
+            meth = klass.instance_method(name)
+
+            if meth.parameters.size > 0
+              define_method(name) do |*args|
+                __memoized__[:"#{name}_#{args.hash}"] ||= super(*args)
+              end
+            else
+              define_method(name) do
+                __memoized__[name] ||= super()
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -23,5 +23,6 @@ RSpec.describe Dry::Core::Memoizable, '.memoize' do
 
   it 'memoizes method return value with an arg' do
     expect(object.bar(:a)).to be(object.bar(:a))
+    expect(object.bar(:b)).to be(object.bar(:b))
   end
 end

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -1,0 +1,27 @@
+require 'dry/core/memoizable'
+
+RSpec.describe Dry::Core::Memoizable, '.memoize' do
+  subject(:object) do
+    Class.new do
+      include Dry::Core::Memoizable
+
+      def foo
+        ['a', 'ab', 'abc'].max
+      end
+      memoize :foo
+
+      def bar(arg)
+        { a: '1', b: '2' }
+      end
+      memoize :bar
+    end.new
+  end
+
+  it 'memoizes method return value' do
+    expect(object.foo).to be(object.foo)
+  end
+
+  it 'memoizes method return value with an arg' do
+    expect(object.bar(:a)).to be(object.bar(:a))
+  end
+end


### PR DESCRIPTION
This copies across `Memoizable` from ROM. Having it in dry-core will make it easier to use across a variety of different places.