### PR TITLE
Allow const autoloading a chance to act

### DIFF
--- a/lib/dry/core/class_builder.rb
+++ b/lib/dry/core/class_builder.rb
@@ -81,6 +81,11 @@ module Dry
 
       # @api private
       def create_base(namespace, name, parent)
+        begin
+          namespace.const_get(name)
+        rescue NameError
+        end
+
         if namespace.const_defined?(name, false)
           existing = namespace.const_get(name)
 

--- a/spec/dry/core/class_builder_spec.rb
+++ b/spec/dry/core/class_builder_spec.rb
@@ -108,6 +108,34 @@ RSpec.describe Dry::Core::ClassBuilder do
           expect(Test::File).not_to be(::File)
         end
       end
+
+      context 'autoloaded constant' do
+        before do
+          Test.module_eval do
+            autoload :Project, File.join(__dir__, "../../fixtures/project")
+          end
+        end
+
+        after do
+          Test.module_eval do
+            remove_const(:Project)
+          end
+        end
+
+        let(:parent) do
+          Test::Parent = Class.new
+        end
+
+        let(:options) do
+          { name: 'Project', namespace: Test, parent: parent }
+        end
+
+        it 'autoloads the specified class' do
+          expect(klass.name).to eq('Test::Project')
+          expect(klass.superclass).to be(Test::Project)
+          expect(klass.instance_methods).to include(:to_model)
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/project.rb
+++ b/spec/fixtures/project.rb
@@ -1,0 +1,5 @@
+Test::Project = Class.new(Test::Parent) do
+  def to_model
+    "Project"
+  end
+end


### PR DESCRIPTION
(I've had more time to investigate #25 this morning and I think I've come up with a solution that will work in all cases.)

Particularly, Rails const autoloading. 

In a Rails app where you have models defined under app/models, these constants are loaded as they are referenced... but only when explicitly mentioned or you const_get them (essentially the same action).

When dry-core uses const_defined?, it will _not_ attempt to autoload this constant, and therefore it will not be defined. This causes the ClassBuilder to build a new anonymous class, which is the incorrect behaviour.

The correct behaviour would be to at least _attempt_ to get the constant -- which triggers autoloading -- before checking if it is defined. If the constant is unable to be const_get'd, then we ignore that error and carry on as usual.