### PR TITLE
Store blocks using Dry::Core::ClassAttributes

### DIFF
--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -49,11 +49,26 @@ module Dry
       #    defines :one, :two, type: Dry::Types['strict.int']
       #  end
       #
+      # @example with blocks
+      #
+      #  class Foo
+      #    extend Dry::Core::ClassAttributes
+      #
+      #    defines :say_hello
+      #    say_hello do
+      #     'hello world'
+      #    end
+      #  end
+      #
+      # Foo.say_hello.call #=> 'hello world'
+      #
       def defines(*args, type: Object)
         mod = Module.new do
           args.each do |name|
-            define_method(name) do |value = Undefined|
+            define_method(name) do |value = Undefined, &blk|
               ivar = "@#{name}"
+
+              value = blk if blk
 
               if value == Undefined
                 if instance_variable_defined?(ivar)

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe 'Class Macros' do
       class MyClass
         extend Dry::Core::ClassAttributes
 
-        defines :one, :two, :three
+        defines :one, :two, :three, :say_hello
 
         one 1
         two 2
         three 3
+        say_hello do
+          'hello world'
+        end
       end
 
       class OtherClass < Test::MyClass
@@ -32,6 +35,10 @@ RSpec.describe 'Class Macros' do
     expect(Test::MyClass.one).to eq(1)
     expect(Test::MyClass.two).to eq(2)
     expect(Test::MyClass.three).to eq(3)
+  end
+
+  it 'allows storing blocks' do
+    expect(Test::MyClass.say_hello.call).to eq('hello world')
   end
 
   it 'allows overwriting of inherited values with nil' do


### PR DESCRIPTION
This PR adds the ability to store blocks with `Dry::Core::ClassAttributes`:

```ruby
class MyClass
  extend Dry::Core::ClassAttributes
  
  defines :say_hello
  say_hello do
    'hello world'
  end 
end

MyClass.say_hello.call #=> "hello world"
```

I look forward to your feedback. Thanks! 😄 


