### PR TITLE
Extensions evaluate in the class/module context

### DIFF
--- a/lib/dry/core/extensions.rb
+++ b/lib/dry/core/extensions.rb
@@ -51,7 +51,7 @@ module Dry
             raise ArgumentError, "Unknown extension: #{ext.inspect}"
           end
           unless @__loaded_extensions__.include?(ext)
-            block.call
+            module_eval(&block)
             @__loaded_extensions__ << ext
           end
         end

--- a/spec/dry/core/extensions_spec.rb
+++ b/spec/dry/core/extensions_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Dry::Core::Extensions do
   subject do
     Class.new do
       extend Dry::Core::Extensions
+
+      def self.define_foo
+        define_method(:foo) {}
+      end
     end
   end
 
@@ -18,6 +22,30 @@ RSpec.describe Dry::Core::Extensions do
 
     expect(foo).to be true
     expect(bar).to be true
+  end
+
+  it 'allows extending with instance methods' do
+    subject.register_extension(:foo) { def foo; end }
+
+    subject.load_extensions(:foo)
+
+    expect(subject.new).to respond_to :foo
+  end
+
+  it 'allows extending with class methods' do
+    subject.register_extension(:foo) { def self.foo; end }
+
+    subject.load_extensions(:foo)
+
+    expect(subject).to respond_to :foo
+  end
+
+  it 'allows extending with execution of class methods' do
+    subject.register_extension(:foo) { define_foo }
+
+    subject.load_extensions(:foo)
+
+    expect(subject.new).to respond_to :foo
   end
 
   it 'swallows double loading' do


### PR DESCRIPTION
This allows execution of class/module scope methods in the extension
definition block. Taking for example a `dry-struct`:

```ruby
class Foo < Dry::Struct
  extend Dry::Core::Extensions

  register_extension(:foo) do
    attribute :foo, Types::Strict::String
  end
end

Foo.load_extensions(:foo)

Foo.new(foo: "foo")
```

Until now, it was expected that the user reopened itself the module or
class to be extended and to call there `.register_extension`. So, the
following wasn't expected to work while now it is allowed:

```ruby
require 'dry/core/extensions'

class Foo
end

Foo.extend(Dry::Core::Extensions)
Foo.register_extension(:bar) do
  def bar
    "bar"
  end
end
Foo.load_extensions(:bar)
Foo.bar # => Before: NoMethodError... Now: "bar"
```

I'm not sure whether this behavior was intentional in order not to monkey patch
from our side. But, if so, I think it was just a delusion because we were just leaving
the user with the dirty job, as `dry-core` extensions will be used one way or
another precisely to do monkey patching :smile: The problem with the previous
implementation was the inability to call class/module scope methods while extending.