### PR TITLE
Fix Documentation for Dry::Core::Constants [ci skip]

### DIFF
--- a/lib/dry/core/constants.rb
+++ b/lib/dry/core/constants.rb
@@ -8,6 +8,7 @@ module Dry
     #
     # @example Just include this module to your class or module
     #   class Foo
+    #     include Dry::Core::Constants
     #     def call(value = EMPTY_ARRAY)
     #        value.map(&:to_s)
     #     end


### PR DESCRIPTION
The example says we should include `Dry::Core::Constants` but the code does not do it