### PR TITLE
Removing guards for ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,7 @@ eval_gemfile 'Gemfile.devtools'
 gemspec
 
 group :test do
-  if RUBY_VERSION >= '2.4'
-    gem 'activesupport'
-  else
-    gem 'activesupport', '~> 4.2'
-  end
+  gem 'activesupport'
   gem 'inflecto', '~> 0.0', '>= 0.0.2'
   gem 'dry-types', '~> 1.0'
   gem 'dry-inflector'

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -8,7 +8,7 @@ group :test do
   gem "simplecov", require: false, platforms: :ruby
   gem "simplecov-cobertura", require: false, platforms: :ruby
 
-  gem "warning" if RUBY_VERSION >= "2.4.0"
+  gem "warning"
 end
 
 group :tools do

--- a/lib/dry/core/class_builder.rb
+++ b/lib/dry/core/class_builder.rb
@@ -72,8 +72,6 @@ module Dry
           remove_const(name)
           const_set(name, klass)
 
-          const_get(name).name if RUBY_VERSION < '2.4'
-
           remove_const(name)
           const_set(name, base)
         end


### PR DESCRIPTION
`Dry::Core` and all other Dry-rb gems requires ruby version 2.4 and above, that makes all the current guards useless since there's no way you can run this gem with something less than ruby 2.4.

Note: For jruby 9.2.12.0 -> RUBY_VERSION = '2.5.7'.