### PR TITLE
Class Attributes: make use of dry-types coercion

### DIFF
--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -65,12 +65,12 @@ module Dry
                 end
               else
                 if type.is_a?(Dry::Types::Type)
-                  instance_variable_set(ivar, type.call(value) { raise InvalidClassAttributeValue.new(name, value) })
+                  value = type.call(value) { raise InvalidClassAttributeValue.new(name, value) }
                 else
                   raise InvalidClassAttributeValue.new(name, value) unless type === value
-
-                  instance_variable_set(ivar, value)
                 end
+
+                instance_variable_set(ivar, value)
               end
             end
           end

--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -64,9 +64,13 @@ module Dry
                   nil
                 end
               else
-                raise InvalidClassAttributeValue.new(name, value) unless type === value
+                if type.is_a?(Dry::Types::Type)
+                  instance_variable_set(ivar, type.call(value) { raise InvalidClassAttributeValue.new(name, value) })
+                else
+                  raise InvalidClassAttributeValue.new(name, value) unless type === value
 
-                instance_variable_set(ivar, value)
+                  instance_variable_set(ivar, value)
+                end
               end
             end
           end

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe 'Class Macros' do
         }.to raise_error(Dry::Core::InvalidClassAttributeValue)
       end
     end
+
+    context 'using coercible dry-types' do
+      before do
+        module Test
+          class Types
+            include Dry::Types()
+          end
+        end
+
+        klass.defines :one, type: Test::Types::Coercible::String
+      end
+
+      it 'allows to pass type option' do
+        klass.one '1'
+        expect(Test::NewClass.one).to eq '1'
+      end
+
+      it 'coerces value based on type option' do
+        klass.one 1
+        expect(Test::NewClass.one).to eq '1'
+      end
+    end
   end
 
   it 'allows inheritance of values' do


### PR DESCRIPTION
So, when I first tried class attributes with dry-types as a type option. My first instinct was that it will make use of the coercions when provided type allows them. Unfortunately, that was not the case. 

Here's my attempt at implementing it :)

Let me know what you think! :beers: