### PR TITLE
Implement coerce option for Class Attributes

### DIFF
--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -68,7 +68,7 @@ module Dry
       #  end
       #
       def defines(*args, type: Object, coerce: proc(&:itself))
-        raise InvalidCoerceOption.new(args[0]) unless coerce.respond_to?(:call)
+        raise ArgumentError, "Non-callable coerce option: #{coerce.inspect}" unless coerce.respond_to?(:call)
 
         mod = Module.new do
           args.each do |name|

--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -68,7 +68,9 @@ module Dry
       #  end
       #
       def defines(*args, type: Object, coerce: proc(&:itself))
-        raise ArgumentError, "Non-callable coerce option: #{coerce.inspect}" unless coerce.respond_to?(:call)
+        unless coerce.respond_to?(:call)
+          raise ArgumentError, "Non-callable coerce option: #{coerce.inspect}"
+        end
 
         mod = Module.new do
           args.each do |name|

--- a/lib/dry/core/errors.rb
+++ b/lib/dry/core/errors.rb
@@ -9,5 +9,13 @@ module Dry
         )
       end
     end
+
+    class InvalidCoerceOption < StandardError
+      def initialize(name)
+        super(
+          "Coerce option for #{name.inspect} class attribute is not callable"
+        )
+      end
+    end
   end
 end

--- a/lib/dry/core/errors.rb
+++ b/lib/dry/core/errors.rb
@@ -9,13 +9,5 @@ module Dry
         )
       end
     end
-
-    class InvalidCoerceOption < StandardError
-      def initialize(name)
-        super(
-          "Coerce option for #{name.inspect} class attribute is not callable"
-        )
-      end
-    end
   end
 end

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe 'Class Macros' do
         expect {
           klass.defines :one, coerce: String
         }.to raise_error(
-          Dry::Core::InvalidCoerceOption,
-          "Coerce option for :one class attribute is not callable"
+          ArgumentError,
+          "Non-callable coerce option: String"
         )
       end
     end

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Class Macros' do
     end
   end
 
-  context 'coerce option' do
+  context "coerce option" do
     let(:klass) do
       module Test
         class NewClass
@@ -106,18 +106,18 @@ RSpec.describe 'Class Macros' do
       Test::NewClass
     end
 
-    context 'using procs' do
+    context "using procs" do
       before do
         klass.defines :one, coerce: proc(&:to_s)
       end
 
-      it 'converts value' do
+      it "converts value" do
         klass.one 1
-        expect(Test::NewClass.one).to eq '1'
+        expect(Test::NewClass.one).to eq "1"
       end
     end
 
-    context 'using dry-types' do
+    context "using dry-types" do
       before do
         module Test
           class Types
@@ -128,23 +128,19 @@ RSpec.describe 'Class Macros' do
         klass.defines :one, coerce: Test::Types::Coercible::String
       end
 
-      it 'converts value' do
+      it "converts value" do
         klass.one 1
-        expect(Test::NewClass.one).to eq '1'
+        expect(Test::NewClass.one).to eq "1"
       end
     end
 
-    context 'using non-callable coerce option' do
-      before do
-        klass.defines :one, coerce: String
-      end
-
-      it 'raises InvalidCoerceOption' do
+    context "using non-callable coerce option" do
+      it "raises InvalidCoerceOption" do
         expect {
-          klass.one 1
+          klass.defines :one, coerce: String
         }.to raise_error(
           Dry::Core::InvalidCoerceOption,
-          'Coerce option for :one class attribute is not callable'
+          "Coerce option for :one class attribute is not callable"
         )
       end
     end

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -95,6 +95,61 @@ RSpec.describe 'Class Macros' do
     end
   end
 
+  context 'coerce option' do
+    let(:klass) do
+      module Test
+        class NewClass
+          extend Dry::Core::ClassAttributes
+        end
+      end
+
+      Test::NewClass
+    end
+
+    context 'using procs' do
+      before do
+        klass.defines :one, coerce: proc(&:to_s)
+      end
+
+      it 'converts value' do
+        klass.one 1
+        expect(Test::NewClass.one).to eq '1'
+      end
+    end
+
+    context 'using dry-types' do
+      before do
+        module Test
+          class Types
+            include Dry::Types()
+          end
+        end
+
+        klass.defines :one, coerce: Test::Types::Coercible::String
+      end
+
+      it 'converts value' do
+        klass.one 1
+        expect(Test::NewClass.one).to eq '1'
+      end
+    end
+
+    context 'using non-callable coerce option' do
+      before do
+        klass.defines :one, coerce: String
+      end
+
+      it 'raises InvalidCoerceOption' do
+        expect {
+          klass.one 1
+        }.to raise_error(
+          Dry::Core::InvalidCoerceOption,
+          'Coerce option for :one class attribute is not callable'
+        )
+      end
+    end
+  end
+
   it 'allows inheritance of values' do
     expect(Test::OtherClass.one).to eq(1)
   end


### PR DESCRIPTION
Added a `coerce` option to Class Attributes instead of introducing breaking changes for the `type` option (related: https://github.com/dry-rb/dry-core/pull/42)