### PR TITLE
Support for Ruby 2.7+, extended test coverage and cache support for &blocks

### DIFF
--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -33,8 +33,6 @@ module Dry
         klass.extend(ClassInterface)
       end
 
-      attr_reader :__memoized__
-
       # @api private
       class Memoizer < Module
         include KeywordArguments
@@ -45,15 +43,15 @@ module Dry
             define_method(name) do |*args, &block|
               id = [name, args, block]
 
-              if __memoized__.key?(id)
-                next __memoized__[id]
+              if @__memoized__.key?(id)
+                next @__memoized__[id]
               end
 
               if !defined?(super) && !respond_to_missing?(name, true)
                 raise NoMethodError, "Undefined memoized method [#{klass}##{name}]"
               end
 
-              __memoized__[id] = super(*args, &block)
+              @__memoized__[id] = super(*args, &block)
             end
           end
         end

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -5,8 +5,17 @@ require_relative "constants"
 module Dry
   module Core
     module Memoizable
+      module KeywordArguments
+        if respond_to?(:ruby2_keywords, true)
+          def method_added(method)
+            ruby2_keywords(method)
+          end
+        end
+      end
+
       module ClassInterface
         include Core::Constants
+        extend KeywordArguments
 
         def memoize(*names)
           prepend(Memoizer.new(names))
@@ -16,10 +25,6 @@ module Dry
           obj = super
           obj.instance_eval { @__memoized__ = EMPTY_HASH.dup }
           obj
-        end
-
-        if respond_to?(:ruby2_keywords, true)
-          ruby2_keywords(:new)
         end
       end
 
@@ -32,6 +37,8 @@ module Dry
 
       # @api private
       class Memoizer < Module
+        include KeywordArguments
+
         # @api private
         def initialize(names)
           names.each do |name|
@@ -43,10 +50,6 @@ module Dry
               else
                 __memoized__[id] = super(*args, &block)
               end
-            end
-
-            if respond_to?(:ruby2_keywords, true)
-              ruby2_keywords(name)
             end
           end
         end

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/core/memoizable"
+require "forwardable"
 
 RSpec.describe Dry::Core::Memoizable do
   extend(Module.new {
@@ -66,6 +67,53 @@ RSpec.describe Dry::Core::Memoizable do
 
   describe "Memoizer#klass" do
     let(:spy) { double("spy") }
+
+    describe "falsy return values" do
+      let(:object) do
+        Class.new(Struct.new(:spy)) do
+          include Dry::Core::Memoizable
+          extend Forwardable
+          delegate call: :spy
+          memoize :call
+        end.new(spy)
+      end
+
+      let(:output) { [described_class] * results.count }
+
+      before do
+        expect(spy).to receive(:call).and_return(described_class).once
+      end
+
+      subject(:results) { 2.times.map { object.call } }
+
+      describe false do
+        it { is_expected.to eq(output) }
+      end
+
+      describe nil do
+        it { is_expected.to eq(output) }
+      end
+
+      describe 0 do
+        it { is_expected.to eq(output) }
+      end
+
+      describe "\n" do
+        it { is_expected.to eq(output) }
+      end
+
+      describe Dry::Core::Constants::EMPTY_HASH do
+        it { is_expected.to eq(output) }
+      end
+
+      describe Dry::Core::Constants::EMPTY_STRING do
+        it { is_expected.to eq(output) }
+      end
+
+      describe Dry::Core::Constants::EMPTY_ARRAY do
+        it { is_expected.to eq(output) }
+      end
+    end
 
     context "given a base class including [Memoizable]" do
       context "given a superclass [BasicObject]" do

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe Dry::Core::Memoizable do
   describe "Memoizer#klass" do
     let(:spy) { double("spy") }
 
+    describe "non-existing methods" do
+      let(:object) do
+        Class.new do
+          include Dry::Core::Memoizable
+          memoize :does_not_exist
+        end.new
+      end
+
+      it "raises an error" do
+        expect { object.does_not_exist }.to raise_error do |error|
+          expect(error).to be_a(NoMethodError)
+          expect(error.message).to include("does_not_exist", "memoized")
+        end
+      end
+    end
+
     describe "falsy return values" do
       let(:object) do
         Class.new(Struct.new(:spy)) do

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -2,54 +2,175 @@
 
 require "dry/core/memoizable"
 
-RSpec.describe Dry::Core::Memoizable, ".memoize" do
-  subject(:object) do
-    Class.new do
-      include Dry::Core::Memoizable
+RSpec.describe Dry::Core::Memoizable do
+  extend(Module.new {
+    ARGS = [[], [true]].freeze
+    BLOCK = [nil, -> { true }].freeze
+    KWARGS = [{}, {key: true}].freeze
 
-      attr_reader :falsey_call_count
+    def calls(&callback)
+      [0, 0, 0, 1, 1, 1].permutation(6) do |args|
+        callback.call(*to_obj(*args[0...3]), *to_obj(*args[3...6]))
+      end
+    end
 
-      def initialize
-        @falsey_call_count = 0
+    def to_obj(arg_id, kwarg_id, block_id)
+      call = {
+        kwargs: KWARGS[kwarg_id],
+        block: BLOCK[block_id],
+        args: ARGS[arg_id]
+      }
+
+      [call, call.merge(block: BLOCK[block_id]&.call)]
+    end
+  })
+
+  describe ".new" do
+    context "given constructor arguments [*args, **kwargs, &block]" do
+      let(:args) { [double("arg")] }
+      let(:kwargs) { {key: double("value")} }
+      let(:block) { -> { double("block") } }
+
+      let(:object) do
+        Class.new do
+          include Dry::Core::Memoizable
+          attr_reader :args, :kwargs, :block
+
+          def initialize(*args, **kwargs, &block)
+            @args = args
+            @kwargs = kwargs
+            @block = block
+          end
+        end.new(*args, **kwargs, &block)
       end
 
-      def foo
-        ["a", "ab", "abc"].max
+      describe "#args" do
+        subject { object.args }
+
+        it { is_expected.to eq(args) }
       end
-      memoize :foo
 
-      def bar(arg)
-        { a: "1", b: "2" }
+      describe "#kwargs" do
+        subject { object.kwargs }
+
+        it { is_expected.to eq(kwargs) }
       end
-      memoize :bar
 
-      def falsey
-        @falsey_call_count += 1
-        false
+      describe "#block" do
+        subject { object.block }
+
+        it { is_expected.to eq(block) }
       end
-      memoize :falsey
-    end.new
+    end
   end
 
-  it "memoizes method return value" do
-    expect(object.foo).to be(object.foo)
-  end
+  describe "Memoizer#klass" do
+    let(:spy) { double("spy") }
 
-  it "memoizes method return value with an arg" do
-    expect(object.bar(:a)).to be(object.bar(:a))
-    expect(object.bar(:b)).to be(object.bar(:b))
-  end
+    context "given a base class including [Memoizable]" do
+      context "given a superclass [BasicObject]" do
+        let(:object) do
+          Class.new(BasicObject) do
+            include Dry::Core::Memoizable
+            memoize :call
 
-  it "memoizes falsey values" do
-    expect(object.falsey).to be(object.falsey)
-    expect(object.falsey_call_count).to eq 1
-  end
+            def initialize(spy)
+              @spy = spy
+            end
 
-  context "frozen object" do
-    before { object.freeze }
+            def call
+              @spy.call
+            end
+          end.new(spy)
+        end
 
-    it "works" do
-      expect(object.foo).to be(object.foo)
+        describe "#call" do
+          before do
+            expect(spy).to receive(:call).and_return(returns).once
+          end
+
+          subject { 2.times.map { object.call } }
+
+          let(:returns) { double("returns") }
+
+          it { is_expected.to eq([returns, returns]) }
+        end
+      end
+
+      context "given a superclass [Object]" do
+        calls do |call1, input1, call2, input2|
+          describe [input1, input2] do
+            let(:spy) { double("spy") }
+            let(:object) do
+              Class.new(Struct.new(:spy)) do
+                include Dry::Core::Memoizable
+                memoize :call1, :call2, :call
+
+                def method_missing(method, *args, **kwargs, &block)
+                  spy.public_send(method, {args: args, kwargs: kwargs, block: block&.call})
+                end
+              end.new(spy)
+            end
+
+            let(:output1) { double("output1") }
+            let(:output2) { double("output2") }
+            let(:output3) { double("output3") }
+            let(:output4) { double("output4") }
+
+            let(:output) { [output1, output2, output3, output4] }
+
+            before do
+              expect(spy).to receive(:call1).with(input1).and_return(output1).once
+              expect(spy).to receive(:call2).with(input2).and_return(output2).once
+
+              expect(spy).to receive(:call).with(input1).and_return(output3).once
+              expect(spy).to receive(:call).with(input2).and_return(output4).once
+            end
+
+            subject do
+              2.times.each_with_object([]) do |_, acc|
+                acc << object.call1(*call1[:args], **call1[:kwargs], &call1[:block])
+                acc << object.call2(*call2[:args], **call2[:kwargs], &call2[:block])
+
+                acc << object.call(*call1[:args], **call1[:kwargs], &call1[:block])
+                acc << object.call(*call2[:args], **call2[:kwargs], &call2[:block])
+              end
+            end
+
+            describe "given a non-frozen object" do
+              it { is_expected.to include(*output) }
+            end
+
+            describe "given a frozen object" do
+              let(:object) { super().freeze }
+
+              it { is_expected.to include(*output) }
+            end
+          end
+        end
+      end
+    end
+
+    context "given a base class not including [Memoizable]" do
+      let(:object) do
+        Class.new(Struct.new(:spy)) do
+          def call
+            spy.call
+          end
+        end.new(spy)
+      end
+
+      describe "#call" do
+        before do
+          expect(spy).to receive(:call).and_return(returns).twice
+        end
+
+        let(:returns) { double("returns") }
+
+        subject { 2.times.map { object.call } }
+
+        it { is_expected.to eq([returns, returns]) }
+      end
     end
   end
 end

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -107,7 +107,13 @@ RSpec.describe Dry::Core::Memoizable do
                 memoize :call1, :call2, :call
 
                 def method_missing(method, *args, **kwargs, &block)
+                  super unless respond_to_missing?(method)
+
                   spy.public_send(method, {args: args, kwargs: kwargs, block: block&.call})
+                end
+
+                def respond_to_missing?(method, *)
+                  [:call1, :call2, :call].include?(method)
                 end
               end.new(spy)
             end


### PR DESCRIPTION
Various bug fixes and improvements. All of the below changes have test cases.

* `instance_variable_set` was replaced with `instance_eval` as `instance_variable_set` isn't implemented on `BasicObject`. 
* Support for Ruby 2.7+ by calling `ruby2_keywords` on  `new` and memoized methods.  This enables method delegation using `super` in versions above Ruby 2.7. Prior to 2.7, `new(*)` would treat `**kwargs` as part of  `*args`. I.e `new(1, a: 2)` would yield `super(1, {a: 2})`. In Ruby 2.7 `{a: 2}` would not be recognised as a keyword argument resulting in an `ArgumentError` error. The solution is to invoke `ruby2_keywords`.
* The argument `&block` is now part of the hash key.
* The hash key is now an array of arguments instead of a string. Methods on `Hash`, such as `Hash#key?` automatically call `#hash` on its input.
* Replaced the frozen, empty hash `MEMOIZED_HASH` used for cache storage with `Core::Constants::EMPTY_HASH`.
* The tests suite now tests for key overlap for three different types of input; `*args`, `**kwargs` and `&block` That is; two memoized method calls with different arguments should not return the same value. The arguments are generated using `Array#permutation` during testing. Removing any part of the hash key, say `id = [name, args, block]` to `id = [name, args]` causes the specs to fail as `call` and `call { }` yields the same cached value.
* `memoize` can now be called anywhere in the class. Before `klass.instance_method(name)` was called whenever `memoize` was invoked. As this is no longer part of the implementation, `memoize` can now be called before a method is defined. ~We might want to make sure the method we’re memoizing is defined at some point to prevent `super` from raising an error during runtime. Suggestions are welcome.~ Fixed in 16be5c0.
* Dynamically defined methods, i.e `method_missing` can now be memoized. 

I just read this in the contribution guidelines:

> A Pull Request will only be accepted if it addresses a specific issue that was reported previously, or fixes typos, mistakes in documentation etc.

Let me know if you want me to create issues for the above changes.