### PR TITLE
Add support for keyword arguments in Ruby 2.7+

### DIFF
--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -30,6 +30,10 @@ module Dry
             obj.instance_variable_set(:'@__memoized__', MEMOIZED_HASH.dup)
             obj
           end
+
+          if respond_to?(:ruby2_keywords, true)
+            ruby2_keywords(:new)
+          end
         end
       end
 
@@ -69,6 +73,10 @@ module Dry
               end
             end
           RUBY
+
+          if respond_to?(:ruby2_keywords, true)
+            ruby2_keywords(method.name)
+          end
         end
 
         # @api private

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -67,4 +67,41 @@ RSpec.describe Dry::Core::Memoizable do
       end
     end
   end
+
+  describe ".new" do
+    let(:args) { [double("arg")] }
+    let(:kwargs) { {key: double("value")} }
+    let(:block) { -> { double("block") } }
+
+    let(:object) do
+      Class.new do
+        include Dry::Core::Memoizable
+        attr_reader :args, :kwargs, :block
+
+        def initialize(*args, **kwargs, &block)
+          @args = args
+          @kwargs = kwargs
+          @block = block
+        end
+      end.new(*args, **kwargs, &block)
+    end
+
+    describe "#args" do
+      subject { object.args }
+
+      it { is_expected.to eq(args) }
+    end
+
+    describe "#kwargs" do
+      subject { object.kwargs }
+
+      it { is_expected.to eq(kwargs) }
+    end
+
+    describe "#block" do
+      subject { object.block }
+
+      it { is_expected.to eq(block) }
+    end
+  end
 end

--- a/spec/support/shared_examples/memoizable.rb
+++ b/spec/support/shared_examples/memoizable.rb
@@ -26,6 +26,11 @@ RSpec.shared_examples "a memoizable class" do
       end
       memoize :bar_with_block
 
+      def bar_with_kwargs(*args, **kwargs)
+        {args: args, kwargs: kwargs}
+      end
+      memoize :bar_with_kwargs
+
       def falsey
         @falsey_call_count += 1
         false
@@ -46,6 +51,15 @@ RSpec.shared_examples "a memoizable class" do
   it "memoizes falsey values" do
     expect(object.falsey).to be(object.falsey)
     expect(object.falsey_call_count).to eq 1
+  end
+
+  describe "keyword arguments" do
+    let(:kwargs) { {key: "value"} }
+    let(:args) { [1] }
+
+    it "memoizes keyword arguments" do
+      expect(object.bar_with_kwargs(*args, **kwargs)).to eq({args: args, kwargs: kwargs})
+    end
   end
 
   describe "with block" do
@@ -85,8 +99,7 @@ RSpec.shared_examples "a memoizable class" do
   end
 end
 
-
-RSpec.shared_examples 'a memoized method' do
+RSpec.shared_examples "a memoized method" do
   let(:new_meth) { described_class }
   let(:old_meth) { new_meth.super_method }
 


### PR DESCRIPTION
See: https://github.com/dry-rb/dry-core/pull/46

Comment `lib/dry/core/memoizable.rb:20` and/or `lib/dry/core/memoizable.rb:62` for specs to fail.

Normally I would use [doubles](https://relishapp.com/rspec/rspec-mocks/v/3-10/docs/verifying-doubles/using-an-instance-double) to verify method invocations (as seen in #46) but wanted to keep the changes to a minimum. Let me know if you want me to add this to the test suite. I'm currently not verifying that `bar_with_kwargs` is actually cached, only that the arguments are correct.