### PR TITLE
Add support for memoized methods with block arguments

### DIFF
--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -60,7 +60,7 @@ module Dry
         def define_memoizable(method:)
           module_eval <<~RUBY, __FILE__, __LINE__ + 1
             def #{method.name}(#{to_declaration(method.parameters)})
-              key = [__method__] + local_variables.map { |var| eval(var.to_s) }
+              key = [Kernel.__method__] + Kernel.local_variables.map { |var| Kernel.eval(var.to_s) }
 
               if @__memoized__.key?(key)
                 @__memoized__[key]

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -65,13 +65,13 @@ module Dry
             meth = klass.instance_method(name)
 
             if meth.parameters.size > 0
-              define_method(name) do |*args|
-                name_with_args = :"#{name}_#{args.hash}"
+              define_method(name) do |*args, &block|
+                name_with_args = :"#{name}_#{args.hash}_#{block.hash}"
 
                 if __memoized__.key?(name_with_args)
                   __memoized__[name_with_args]
                 else
-                  __memoized__[name_with_args] = super(*args)
+                  __memoized__[name_with_args] = super(*args, &block)
                 end
               end
             else

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -43,47 +43,56 @@ module Dry
         end
       end
 
-      attr_reader :__memoized__
-
       # @api private
       class Memoizer < Module
-        attr_reader :klass
-        attr_reader :names
-
         # @api private
         def initialize(klass, names)
-          @names = names
-          @klass = klass
-          define_memoizable_names!
+          names.each do |name|
+            define_memoizable(
+              method: klass.instance_method(name)
+            )
+          end
         end
 
         private
 
         # @api private
-        def define_memoizable_names!
-          names.each do |name|
-            meth = klass.instance_method(name)
+        def define_memoizable(method:)
+          module_eval <<~RUBY, __FILE__, __LINE__ + 1
+            def #{method.name}(#{to_declaration(method.parameters)})
+              key = [__method__] + local_variables.map { |var| eval(var.to_s) }
 
-            if meth.parameters.size > 0
-              define_method(name) do |*args, &block|
-                name_with_args = :"#{name}_#{args.hash}_#{block.hash}"
-
-                if __memoized__.key?(name_with_args)
-                  __memoized__[name_with_args]
-                else
-                  __memoized__[name_with_args] = super(*args, &block)
-                end
-              end
-            else
-              define_method(name) do
-                if __memoized__.key?(name)
-                  __memoized__[name]
-                else
-                  __memoized__[name] = super()
-                end
+              if @__memoized__.key?(key)
+                @__memoized__[key]
+              else
+                @__memoized__[key] = super
               end
             end
-          end
+          RUBY
+        end
+
+        # @api private
+        def to_declaration(params, lookup = params.to_h)
+          params.map do |type, name|
+            case type
+            when :req
+              name
+            when :rest
+              "*#{name}"
+            when :keyreq
+              "#{name}:"
+            when :keyrest
+              "**#{name}"
+            when :block
+              "&#{name}"
+            when :opt
+              lookup.key?(:rest) ? nil : "*args"
+            when :key
+              lookup.key?(:keyrest) ? nil : "**kwargs"
+            else
+              raise NotImplementedError, "type: #{type}, name: #{name}"
+            end
+          end.compact.join(", ")
         end
       end
     end

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -1,29 +1,70 @@
 # frozen_string_literal: true
 
 require "dry/core/memoizable"
+require_relative "../../support/memoized"
 
-RSpec.describe Dry::Core::Memoizable, ".memoize" do
-  describe Object do
-    it_behaves_like "a memoizable class" do
-      context "frozen object" do
-        before { object.freeze }
+RSpec.describe Dry::Core::Memoizable do
+  describe ".memoize" do
+    describe Object do
+      it_behaves_like "a memoizable class" do
+        context "frozen object" do
+          before { object.freeze }
 
-        it "works" do
-          expect(object.foo).to be(object.foo)
+          it "works" do
+            expect(object.foo).to be(object.foo)
+          end
         end
       end
     end
+
+    describe BasicObject do
+      it_behaves_like "a memoizable class"
+    end
+
+    describe Class.new(Object) do
+      it_behaves_like "a memoizable class"
+    end
+
+    describe Class.new(BasicObject) do
+      it_behaves_like "a memoizable class"
+    end
   end
 
-  describe BasicObject do
-    it_behaves_like "a memoizable class"
-  end
+  describe Memoized.new do
+    let(:block) { -> {} }
 
-  describe Class.new(Object) do
-    it_behaves_like "a memoizable class"
-  end
+    describe described_class.method(:test1) do
+      it_behaves_like "a memoized method"
 
-  describe Class.new(BasicObject) do
-    it_behaves_like "a memoizable class"
+      it "does not raise an error" do
+        2.times do
+          described_class.call("a", kwarg1: "world", other: "test", &block)
+        end
+      end
+    end
+
+    describe described_class.method(:test2) do
+      it_behaves_like "a memoized method"
+
+      it "does not raise an error" do
+        2.times { described_class.call("a", &block) }
+      end
+    end
+
+    describe described_class.method(:test3) do
+      it_behaves_like "a memoized method"
+
+      it "does not raise an error" do
+        2.times { described_class.call(&block) }
+      end
+    end
+
+    describe described_class.method(:test4) do
+      it_behaves_like "a memoized method"
+
+      it "does not raise an error" do
+        2.times { described_class.call }
+      end
+    end
   end
 end

--- a/spec/support/memoized.rb
+++ b/spec/support/memoized.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Memoized
+  include Dry::Core::Memoizable
+
+  def test1(arg1, *args, kwarg1:, kwarg2: "default", **kwargs, &block)
+    # NOP
+  end
+
+  def test2(arg1, arg2 = "default", *args, &block)
+    # NOP
+  end
+
+  def test3(&block)
+    # NOP
+  end
+
+  def test4
+    # NOP
+  end
+
+  memoize :test1, :test2, :test3, :test4
+end

--- a/spec/support/shared_examples/memoizable.rb
+++ b/spec/support/shared_examples/memoizable.rb
@@ -84,3 +84,24 @@ RSpec.shared_examples "a memoizable class" do
     it { is_expected.to match_array(returns) }
   end
 end
+
+
+RSpec.shared_examples 'a memoized method' do
+  let(:new_meth) { described_class }
+  let(:old_meth) { new_meth.super_method }
+
+  describe "new != old" do
+    subject { new_meth }
+    it { is_expected.not_to eq(old_meth) }
+  end
+
+  describe "new.arity == old.arity" do
+    subject { new_meth.arity }
+    it { is_expected.to eq(old_meth.arity) }
+  end
+
+  describe "new.name == old.name" do
+    subject { new_meth.name }
+    it { is_expected.to eq(old_meth.name) }
+  end
+end

--- a/spec/support/shared_examples/memoizable.rb
+++ b/spec/support/shared_examples/memoizable.rb
@@ -21,6 +21,11 @@ RSpec.shared_examples "a memoizable class" do
       end
       memoize :bar
 
+      def bar_with_block(&block)
+        block.call
+      end
+      memoize :bar_with_block
+
       def falsey
         @falsey_call_count += 1
         false
@@ -41,5 +46,41 @@ RSpec.shared_examples "a memoizable class" do
   it "memoizes falsey values" do
     expect(object.falsey).to be(object.falsey)
     expect(object.falsey_call_count).to eq 1
+  end
+
+  describe "with block" do
+    let(:spy1) { double(:spy1) }
+    let(:spy2) { double(:spy2) }
+    let(:block1) { -> { spy1.call } }
+    let(:block2) { -> { spy2.call } }
+    let(:returns1) { :return_value1 }
+    let(:returns2) { :return_value2 }
+
+    before do
+      expect(spy1).to receive(:call).and_return(returns1).once
+      expect(spy2).to receive(:call).and_return(returns2).once
+    end
+
+    let(:results1) do
+      2.times.map do
+        object.bar_with_block(&block1)
+      end
+    end
+
+    let(:results2) do
+      2.times.map do
+        object.bar_with_block(&block2)
+      end
+    end
+
+    let(:returns) do
+      [returns1, returns2] * 2
+    end
+
+    subject do
+      results1 + results2
+    end
+
+    it { is_expected.to match_array(returns) }
   end
 end


### PR DESCRIPTION
See #46.

Two calls to a memoized method with different block arguments will now be cached separately.