### PR TITLE
Allow printing frame info on warn

### DIFF
--- a/lib/dry/core/deprecations.rb
+++ b/lib/dry/core/deprecations.rb
@@ -33,17 +33,24 @@ module Dry
         # Prints a warning
         #
         # @param [String] msg Warning string
-        def warn(msg, tag: nil)
-          tagged = "[#{tag || 'deprecated'}] #{msg.gsub(/^\s+/, '')}"
-          logger.warn(tagged)
+        # @param [String] tag Tag to help identify the source of the warning.
+        #   Defaults to "deprecated"
+        # @param [Integer] Caller frame to add to the message
+        def warn(msg, tag: nil, uplevel: nil)
+          caller_info = uplevel.nil? ? nil : caller[uplevel]
+          tag = "[#{tag || "deprecated"}]"
+          hint = msg.gsub(/^\s+/, "")
+          logger.warn(
+            [caller_info, tag, hint].compact.join(" ")
+          )
         end
 
         # Wraps arguments with a standard message format and prints a warning
         #
         # @param [Object] name what is deprecated
         # @param [String] msg additional message usually containing upgrade instructions
-        def announce(name, msg, tag: nil)
-          warn(deprecation_message(name, msg), tag: tag)
+        def announce(name, msg, tag: nil, uplevel: nil)
+          warn(deprecation_message(name, msg), tag: tag, uplevel: uplevel)
         end
 
         # @api private

--- a/spec/dry/core/deprecations_spec.rb
+++ b/spec/dry/core/deprecations_spec.rb
@@ -27,13 +27,19 @@ RSpec.describe Dry::Core::Deprecations do
       Dry::Core::Deprecations.warn("hello world", tag: :spec)
       expect(log_output).to include("[spec] hello world")
     end
+
+    it "prints information about the caller frame if uplevel is given" do
+      Dry::Core::Deprecations.warn("hello world", uplevel: 0)
+      expect(log_output).to include(FileUtils.pwd)
+    end
   end
 
   describe ".announce" do
     it "warns about a deprecated method" do
-      Dry::Core::Deprecations.announce(:foo, "hello world", tag: :spec)
+      Dry::Core::Deprecations.announce(:foo, "hello world", tag: :spec, uplevel: 0)
       expect(log_output).to include("[spec] foo is deprecated and will be removed")
       expect(log_output).to include("hello world")
+      expect(log_output).to include(FileUtils.pwd)
     end
   end
 


### PR DESCRIPTION
A new `uplevel` can be given on `Dry::Core::Deprecations.warn` &&
`Dry::Core::Deprecations.announce` to print information of the given
caller frame. E.g.:

```
irb(main):001:0> require 'dry/core/deprecations'
=> true
irb(main):002:1* class A
irb(main):003:2*   def a
irb(main):004:2*     Dry::Core::Deprecations.warn('a is deprecated', uplevel: 1)
irb(main):005:1*   end
irb(main):006:1* end
=> :a
irb(main):007:0* A.new.a
/home/root/bin/console:7:in `<main>' [deprecated] a is deprecated
=> true
``