### PR TITLE
Refactor memoziation

### DIFF
--- a/lib/dry/core/deprecations.rb
+++ b/lib/dry/core/deprecations.rb
@@ -113,8 +113,9 @@ module Dry
       end
 
       # @api private
-      class Tagged < Module
+      class Tagged < ::Module
         def initialize(tag)
+          super()
           @tag = tag
         end
 

--- a/lib/dry/core/equalizer.rb
+++ b/lib/dry/core/equalizer.rb
@@ -14,7 +14,7 @@ module Dry
 
   module Core
     # Define equality, equivalence and inspection methods
-    class Equalizer < Module
+    class Equalizer < ::Module
       # Initialize an Equalizer with the given keys
       #
       # Will use the keys with which it is initialized to define #cmp?,
@@ -29,6 +29,7 @@ module Dry
       #
       # @api private
       def initialize(*keys, **options)
+        super()
         @keys = keys.uniq
         define_methods(**options)
         freeze

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -126,7 +126,7 @@ module Dry
         end
 
         # @api private
-        def map_bind_type(type, original_params, defined_types)
+        def map_bind_type(type, original_params, defined_types) # rubocop:disable Metrics/PerceivedComplexity
           case type
           when :req
             :reqular

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -80,8 +80,8 @@ module Dry
             params, binds = declaration(parameters, mapping)
 
             module_eval <<~RUBY, __FILE__, __LINE__ + 1
-              def #{method.name}(#{params.join(', ')})
-                key = [:"#{method.name}", #{binds.join(', ')}].hash
+              def #{method.name}(#{params.join(", ")})
+                key = [:"#{method.name}", #{binds.join(", ")}].hash
 
                 if @__memoized__.key?(key)
                   @__memoized__[key]

--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -48,9 +48,10 @@ module Dry
       end
 
       # @api private
-      class Memoizer < Module
+      class Memoizer < ::Module
         # @api private
         def initialize(klass, names)
+          super()
           names.each do |name|
             define_memoizable(
               method: klass.instance_method(name)

--- a/spec/support/memoized.rb
+++ b/spec/support/memoized.rb
@@ -19,5 +19,21 @@ class Memoized
     # NOP
   end
 
-  memoize :test1, :test2, :test3, :test4
+  def test5(args, *)
+    # NOP
+  end
+
+  def test6(kwargs, **)
+    # NOP
+  end
+
+  def test7(args, kwargs, *, **)
+    # NOP
+  end
+
+  def test8(args = 1, kwargs = 2, *, **)
+    # NOP
+  end
+
+  memoize :test1, :test2, :test3, :test4, :test5, :test6, :test7, :test8
 end


### PR DESCRIPTION
This removed using of `Kernel.eval`. It's not necessary to "resort" to such a thing. There's local_variable_get but even this can be avoided by careful picking bind names.

This commit also fixes ruby 3 keyword warnings from improper use of ruby2_keywords when there're no keywords in the definition. I'll add more specs in the following commits to make sure it doesn't break for various declarations.

Finally, I made zero args a special case, this way we save quite a few allocations which is nice for perf.