### PR TITLE
Show more relevant caller info for deprecation warnings

### DIFF
--- a/lib/dry/core/deprecations.rb
+++ b/lib/dry/core/deprecations.rb
@@ -37,9 +37,10 @@ module Dry
         #   Defaults to "deprecated"
         # @param [Integer] Caller frame to add to the message
         def warn(msg, tag: nil, uplevel: nil)
-          caller_info = uplevel.nil? ? nil : "#{caller_locations(uplevel + 1, 1)[0]} "
+          caller_info = uplevel.nil? ? nil : "#{caller_locations(uplevel + 2, 1)[0]} "
           tag = "[#{tag || "deprecated"}] "
           hint = msg.gsub(/^\s+/, "")
+
           logger.warn("#{caller_info}#{tag}#{hint}")
         end
 
@@ -48,6 +49,10 @@ module Dry
         # @param [Object] name what is deprecated
         # @param [String] msg additional message usually containing upgrade instructions
         def announce(name, msg, tag: nil, uplevel: nil)
+          # Bump the uplevel (if provided) by one to account for the uplevel calculation
+          # taking place one frame deeper in `.warn`
+          uplevel += 1 if uplevel
+
           warn(deprecation_message(name, msg), tag: tag, uplevel: uplevel)
         end
 

--- a/spec/dry/core/deprecations_spec.rb
+++ b/spec/dry/core/deprecations_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Dry::Core::Deprecations do
 
     it "prints information about the caller frame if uplevel is given" do
       Dry::Core::Deprecations.warn("hello world", uplevel: 0)
-      expect(log_output).to include(FileUtils.pwd)
+      expect(log_output).to include("/rspec/")
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Dry::Core::Deprecations do
       Dry::Core::Deprecations.announce(:foo, "hello world", tag: :spec, uplevel: 0)
       expect(log_output).to include("[spec] foo is deprecated and will be removed")
       expect(log_output).to include("hello world")
-      expect(log_output).to include(FileUtils.pwd)
+      expect(log_output).to include("/rspec/")
     end
   end
 


### PR DESCRIPTION
This changes the default `uplevel` arg for `caller_locations` from 1 to 2, which means we skip (1) the Deprecations.warn method itself, and then (2) the line from whatever gem is warning about the deprecation.

This means we end up showing the line from the code calling _into_ the deprecated behavior, which is (in most cases) where any kind of code fix should be made by the user.

Before this change, I was seeing the following kinds of deprecation warnings printed when running Hanami's test suite:

```
/Users/tim/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/dry-configurable-00f8b8e64898/lib/dry/configurable/class_methods.rb:41:in `setting' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead

/Users/tim/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/dry-configurable-00f8b8e64898/lib/dry/configurable/class_methods.rb:41:in `setting' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```

In this output, practically every deprecation warning had an identical source code reference, to this place _within_ dry-configurable that was announcing the deprecated behavior. This is not helpful, because I can't tell what's calling _into_ that behavior! Without this information, I don't know where to look to fix whichever code is invoking that deprecated behavior.

After this change, I now see lines like these:

```
/Users/tim/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/controller-8be91849823d/lib/hanami/action/application_configuration.rb:20:in `<class:ApplicationConfiguration>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead

/Users/tim/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/view-1b3be6576194/lib/hanami/view/application_configuration.rb:11:in `<class:ApplicationConfiguration>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```

This is much more useful, because I can now jump into those files and make the necessary adjustments to silence the warnings.

@flash-gordon, @waiting-for-dev, as the folks who've recently worked on this (very helpful!) new part of our deprecation notices, does this make sense?