### PR TITLE
Use Class#subclasses for DescendantTracker

### DIFF
--- a/lib/dry/core/descendants_tracker.rb
+++ b/lib/dry/core/descendants_tracker.rb
@@ -61,7 +61,7 @@ module Dry
         if ancestor.respond_to?(:add_descendant, true)
           ancestor.add_descendant(descendant)
         end
-        descendants.unshift(descendant)
+        descendants.push(descendant)
       end
 
       private

--- a/spec/dry/core/descendants_tracker_spec.rb
+++ b/spec/dry/core/descendants_tracker_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe Dry::Core::DescendantsTracker do
   end
 
   it "tracks descendants" do
-    expect(Test::Parent.descendants).to eql([Test::Grandchild, Test::Child])
+    expect(Test::Parent.descendants).to eql([Test::Child, Test::Grandchild])
   end
 end


### PR DESCRIPTION
This is a 3.1+ feature. I would expect this to work slower compared to the previous implementation, OTOH `.descendants` normally called a limited number of times. Also, the new version doesn't hold hard references to classes which is good for code reloading.