### PR TITLE
Import dry-equalizer documentation

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -32,7 +32,7 @@
   changed:
 - version: 0.5.0
   summary:
-  date: '2012-12-12'
+  date: '2020-12-12'
   fixed:
   added:
   - dry-equalizer has been imported into dry-core as `Dry::Core::Equalizer` but the

--- a/docsite/source/equalizer.html.md
+++ b/docsite/source/equalizer.html.md
@@ -1,0 +1,84 @@
+---
+title: Equalizer
+description: Simple mixin providing equality, equivalence and inspection methods
+layout: gem-single
+name: dry-core
+---
+
+A simple mixin that can be used to add instance variable based equality, equivalence and inspection methods to your objects.
+
+### Usage
+
+```ruby
+require 'dry/core/equalizer'
+
+class GeoLocation
+  include Dry::Core::Equalizer(:latitude, :longitude)
+
+  attr_reader :latitude, :longitude
+
+  def initialize(latitude, longitude)
+    @latitude, @longitude = latitude, longitude
+  end
+end
+
+point_a = GeoLocation.new(1, 2)
+point_b = GeoLocation.new(1, 2)
+point_c = GeoLocation.new(2, 2)
+
+point_a.inspect    # => "#<GeoLocation latitude=1 longitude=2>"
+
+point_a == point_b           # => true
+point_a.hash == point_b.hash # => true
+point_a.eql?(point_b)        # => true
+point_a.equal?(point_b)      # => false
+
+point_a == point_c           # => false
+point_a.hash == point_c.hash # => false
+point_a.eql?(point_c)        # => false
+point_a.equal?(point_c)      # => false
+```
+
+### Configuration options
+
+#### `inspect`
+
+Use `inspect` option to skip `#inspect` method overloading:
+
+```ruby
+class Foo
+  include Dry::Core::Equalizer(:a, inspect: false)
+
+  attr_reader :a, :b
+
+  def initialize(a, b)
+    @a, @b = a, b
+  end
+end
+
+Foo.new(1, 2).inspect
+# => "#<Foo:0x00007fbc9c0487f0 @a=1, @b=2>"
+```
+
+#### `immutable`
+
+For objects that are immutable it doesn't make sense to calculate `#hash` every time it's called. To memoize hash use `immutable` option:
+
+```ruby
+class ImmutableHash
+  include Dry::Core::Equalizer(:foo, :bar, immutable: true)
+
+  attr_accessor :foo, :bar
+
+  def initialize(foo, bar)
+    @foo, @bar = foo, bar
+  end
+end
+
+obj = ImmutableHash.new('foo', 'bar')
+old_hash = obj.hash
+obj.foo = 'changed'
+old_hash == obj.hash
+# => true
+```
+

--- a/docsite/source/equalizer.html.md
+++ b/docsite/source/equalizer.html.md
@@ -1,6 +1,5 @@
 ---
 title: Equalizer
-description: Simple mixin providing equality, equivalence and inspection methods
 layout: gem-single
 name: dry-core
 ---

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -22,4 +22,5 @@ sections:
 - [Class Builder](docs::classes/class-builder)
 - [Constants](docs::constants) - a list of constants you can use to avoid memory allocations or identity checks.
 - [Deprecations](docs::deprecations)
+- [Equalizer](docs::equalizer)
 - [Extensions](docs::extensions)

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -22,5 +22,5 @@ sections:
 - [Class Builder](docs::classes/class-builder)
 - [Constants](docs::constants) - a list of constants you can use to avoid memory allocations or identity checks.
 - [Deprecations](docs::deprecations)
-- [Equalizer](docs::equalizer)
+- [Equalizer](docs::equalizer) - simple mixin providing equality, equivalence and inspection methods.
 - [Extensions](docs::extensions)


### PR DESCRIPTION
Dry-equalized was deprecated as its own independent gem and integrated into `dry-core`, so its documentation should be under `dry-core` too.

Copied from https://github.com/dry-rb/dry-equalizer/blob/803df5de6a6b7d5bde9ebe7be6ea60664cf129a1/docsite/source/index.html.md and changed the metadata to match the other files in the same folder. I also changed references to `Dry::Equalizer` to `Dry::Core::Equalizer`, and `require 'dry-equalizer'` to `require 'dry/core/equalizer'`