### PR TITLE
Fixes typo in Memoizable

### DIFF
--- a/lib/dry/core/memoizable.rb
+++ b/lib/dry/core/memoizable.rb
@@ -53,7 +53,7 @@ module Dry
       # @api private
       class Memoizer < ::Module
         KERNEL = {
-          signleton: ::Kernel.instance_method(:singleton_class),
+          singleton: ::Kernel.instance_method(:singleton_class),
           ivar_set: ::Kernel.instance_method(:instance_variable_set),
           frozen: ::Kernel.instance_method(:frozen?)
         }.freeze
@@ -107,7 +107,7 @@ module Dry
                 attr_name = :"__memozed_#{key}__"
                 ivar_name = :"@#{attr_name}"
                 kernel[:ivar_set].bind(self).(ivar_name, value)
-                eigenclass = kernel[:signleton].bind(self).call
+                eigenclass = kernel[:singleton].bind(self).call
                 eigenclass.attr_reader(attr_name)
                 eigenclass.alias_method(method.name, attr_name)
                 eigenclass.remove_method(attr_name)


### PR DESCRIPTION
Just a simple typo for `singleton` that I found reading the code.
