### PR TITLE
Correct missing constant for IDENTITY. Fixes #75

### DIFF
--- a/lib/dry/core/class_attributes.rb
+++ b/lib/dry/core/class_attributes.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require "dry/core/constants"
+
 module Dry
   module Core
     # Internal support module for class-level settings
     #
     # @api public
     module ClassAttributes
+      include Constants
       # Specify what attributes a class will use
       #
       # @example


### PR DESCRIPTION
Correction to include the constant reference needed to avoid receiving `uninitialized constant Dry::Core::ClassAttributes::IDENTITY`.  Fixes #75 