### PR TITLE
Fix Dry::Core::Equalizer() usage

### DIFF
--- a/docsite/source/cache.html.md
+++ b/docsite/source/cache.html.md
@@ -7,7 +7,7 @@ name: dry-core
 Allows you to cache call results that are solely determined by arguments.
 
 ```ruby
-require 'dry/core/cache'
+require "dry/core"
 
 class Foo
   extend Dry::Core::Cache

--- a/docsite/source/deprecations.html.md
+++ b/docsite/source/deprecations.html.md
@@ -7,7 +7,7 @@ name: dry-core
 To deprecate ruby methods you need to extend the `Dry::Core::Deprecations` module with a tag that will be displayed in the output. For example:
 
 ```ruby
-require 'dry/core/deprecations'
+require "dry/core"
 
 class Foo
   extend Dry::Core::Deprecations[:tag]

--- a/docsite/source/equalizer.html.md
+++ b/docsite/source/equalizer.html.md
@@ -9,7 +9,7 @@ A simple mixin that can be used to add instance variable based equality, equival
 ### Usage
 
 ```ruby
-require 'dry/core/equalizer'
+require "dry/core"
 
 class GeoLocation
   include Dry::Core::Equalizer(:latitude, :longitude)

--- a/docsite/source/extensions.html.md
+++ b/docsite/source/extensions.html.md
@@ -7,7 +7,7 @@ name: dry-core
 Define extensions that can be later enabled by the user.
 
 ```ruby
-require 'dry/core/extensions'
+require "dry/core"
 
 class Foo
   extend Dry::Core::Extensions

--- a/lib/dry/core.rb
+++ b/lib/dry/core.rb
@@ -27,6 +27,17 @@ module Dry
     end
 
     loader.setup
+
+    # Build an equalizer module for the inclusion in other class
+    #
+    # ## Credits
+    #
+    # Equalizer has been originally imported from the equalizer gem created by Dan Kubb
+    #
+    # @api public
+    def self.Equalizer(*keys, **options)
+      Equalizer.new(*keys, **options)
+    end
   end
 
   # See dry/core/equalizer.rb

--- a/lib/dry/core/equalizer.rb
+++ b/lib/dry/core/equalizer.rb
@@ -137,6 +137,17 @@ module Dry
         end
       end
     end
+
+    # Build an equalizer module for the inclusion in other class
+    #
+    # ## Credits
+    #
+    # Equalizer has been originally imported from the equalizer gem created by Dan Kubb
+    #
+    # @api public
+    def self.Equalizer(*keys, **options)
+      Dry::Core::Equalizer.new(*keys, **options)
+    end
   end
 
   # Old modules that depend on dry/core/equalizer may miss

--- a/lib/dry/core/equalizer.rb
+++ b/lib/dry/core/equalizer.rb
@@ -137,17 +137,6 @@ module Dry
         end
       end
     end
-
-    # Build an equalizer module for the inclusion in other class
-    #
-    # ## Credits
-    #
-    # Equalizer has been originally imported from the equalizer gem created by Dan Kubb
-    #
-    # @api public
-    def self.Equalizer(*keys, **options)
-      Dry::Core::Equalizer.new(*keys, **options)
-    end
   end
 
   # Old modules that depend on dry/core/equalizer may miss

--- a/spec/dry/core/basic_object_spec.rb
+++ b/spec/dry/core/basic_object_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pp"
-
 class ExternalTestClass
 end
 
@@ -77,6 +75,7 @@ RSpec.describe Dry::Core::BasicObject do
 
     # See https://github.com/hanami/utils/issues/234
     it "outputs the inspection to the given printer" do
+      require "pp" # rubucop:disable Lint/RedundantRequireStatement
       printer = PP.new
       subject = TestClass.new
       subject.pretty_print(printer)

--- a/spec/dry/core/basic_object_spec.rb
+++ b/spec/dry/core/basic_object_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/basic_object"
 require "pp"
 
 class ExternalTestClass

--- a/spec/dry/core/cache_spec.rb
+++ b/spec/dry/core/cache_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/cache"
-
 RSpec.describe Dry::Core::Cache do
   shared_examples_for "class with cache" do
     describe "#fetch_or_store" do

--- a/spec/dry/core/class_attributes_spec.rb
+++ b/spec/dry/core/class_attributes_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/class_attributes"
 require "dry-types"
 
 RSpec.describe "Class Macros" do

--- a/spec/dry/core/class_builder_spec.rb
+++ b/spec/dry/core/class_builder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/class_builder"
-
 RSpec.describe Dry::Core::ClassBuilder do
   subject(:builder) { described_class.new(**options) }
 

--- a/spec/dry/core/constants_spec.rb
+++ b/spec/dry/core/constants_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/constants"
-
 RSpec.describe Dry::Core::Constants do
   before do
     class ClassWithConstants

--- a/spec/dry/core/deprecations_spec.rb
+++ b/spec/dry/core/deprecations_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/deprecations"
 require "tempfile"
 
 RSpec.describe Dry::Core::Deprecations do

--- a/spec/dry/core/descendants_tracker_spec.rb
+++ b/spec/dry/core/descendants_tracker_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/descendants_tracker"
-
 RSpec.describe Dry::Core::DescendantsTracker do
   before do
     module Test

--- a/spec/dry/core/equalizer/included_spec.rb
+++ b/spec/dry/core/equalizer/included_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dry/core/equalizer"
 
 RSpec.describe Dry::Core::Equalizer, "#included" do
   subject { descendant.instance_exec(object) { |mod| include mod } }
@@ -33,7 +32,7 @@ RSpec.describe Dry::Core::Equalizer, "#included" do
 
     superclass.class_eval do
       define_method(:included) do |_|
-        # Only set the flag when an Dry::Equalizer instance is included.
+        # Only set the flag when an Dry::Core::Equalizer instance is included.
         # Otherwise, other module includes (which get triggered internally
         # in RSpec when `change` is used for the first time, since it uses
         # autoloading for its matchers) will wrongly set this flag.

--- a/spec/dry/core/equalizer/legacy_name_spec.rb
+++ b/spec/dry/core/equalizer/legacy_name_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe "legacy Dry::Equalizer name" do
+  it "behaves the same as when using Dry::Core::Equalizer" do
+    klass = Class.new {
+      attr_reader :name
+
+      def initialize(name)
+        @name = name
+      end
+    }
+    allow(klass).to receive_messages(name: nil, inspect: "User") # specify the class #inspect method
+    klass.include Dry::Equalizer(:name)
+
+    instance = klass.new("Jane")
+    other = instance.dup
+
+    expect(instance).to eql(other)
+  end
+end

--- a/spec/dry/core/equalizer/methods/eql_predicate_spec.rb
+++ b/spec/dry/core/equalizer/methods/eql_predicate_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dry/core/equalizer"
 
 RSpec.describe Dry::Core::Equalizer::Methods, "#eql?" do
   subject { object.eql?(other) }

--- a/spec/dry/core/equalizer/methods/equality_operator_spec.rb
+++ b/spec/dry/core/equalizer/methods/equality_operator_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dry/core/equalizer"
 
 RSpec.describe Dry::Core::Equalizer::Methods, "#==" do
   subject { object == other }

--- a/spec/dry/core/equalizer/universal_spec.rb
+++ b/spec/dry/core/equalizer/universal_spec.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dry/core/equalizer"
 
 RSpec.describe Dry::Core::Equalizer do
   let(:name)   { "User"          }
   let(:klass)  { ::Class.new     }
 
   context "with no keys" do
-    subject { Dry::Equalizer() }
+    subject { Dry::Core::Equalizer() }
 
     before do
       # specify the class #name method
@@ -73,7 +72,7 @@ RSpec.describe Dry::Core::Equalizer do
   end
 
   context "with keys" do
-    subject { Dry::Equalizer(*keys) }
+    subject { Dry::Core::Equalizer(*keys) }
 
     let(:keys)       { %i[firstname lastname].freeze  }
     let(:firstname)  { "John"                         }
@@ -158,7 +157,7 @@ RSpec.describe Dry::Core::Equalizer do
 
     context "when immutable" do
       describe "#hash" do
-        subject { Dry::Equalizer(*keys, immutable: true) }
+        subject { Dry::Core::Equalizer(*keys, immutable: true) }
 
         it "returns memoized hash" do
           expect { instance.firstname = "Changed" }.not_to(change { instance.hash })
@@ -177,7 +176,7 @@ RSpec.describe Dry::Core::Equalizer do
   end
 
   context "with duplicate keys" do
-    subject { Dry::Equalizer(*keys) }
+    subject { Dry::Core::Equalizer(*keys) }
 
     let(:keys)       { %i[firstname firstname lastname].freeze  }
     let(:firstname)  { "John"                                   }
@@ -216,7 +215,7 @@ RSpec.describe Dry::Core::Equalizer do
 
   context "with options" do
     context "w/o inspect" do
-      subject { Dry::Equalizer(*keys, inspect: false) }
+      subject { Dry::Core::Equalizer(*keys, inspect: false) }
 
       let(:keys)       { %i[firstname lastname].freeze  }
       let(:firstname)  { "John"                         }

--- a/spec/dry/core/extensions_spec.rb
+++ b/spec/dry/core/extensions_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/extensions"
-
 RSpec.describe Dry::Core::Extensions do
   subject do
     Class.new do

--- a/spec/dry/core/inflector_spec.rb
+++ b/spec/dry/core/inflector_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/inflector"
-
 RSpec.describe Dry::Core::Inflector do
   shared_examples "an inflector" do
     it "singularises" do

--- a/spec/dry/core/memoizable_spec.rb
+++ b/spec/dry/core/memoizable_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "concurrent/atomic/atomic_fixnum"
-require "dry/core/memoizable"
 require "tempfile"
 require_relative "../../support/memoized"
 


### PR DESCRIPTION
As raised by @bkuhlmann in [bkuhlmann/wholable](https://github.com/bkuhlmann/wholable#influences)’s README, the version of dry-equalizer as moved to dry-core:

> doesn’t appear to work properly or be well supported. Even the documentation is not fully linked on the main page.

This PR addresses the “doesn’t appear to work properly” issue. See details below.

Once this is merged and released I’ll also update the 1.0 version of the docs to ensure _Equalizer_ properly appears in the sidebar.

Once both of these are done, I would also hope that the entirety of @bkuhlmann’s statement above is no longer true and can be updated 😄

## Fix Dry::Core::Equalizer() usage

Provide a `Dry::Core.Equalizer` method that builds the module when called as `include Dry::Core::Equalizer()` as documented. Previously, this method did not exist at all, so _only_ usages of the "legacy" `Dry.Equalizer` method would work. With this change, we can now appropriately expect `Dry::Core.Equalizer` to be the mainstream usage.

To ensure this, update the specs to expect `Dry::Core::Equalizer()` to be used by default, and provide a single spec to ensure that the legacy `Dry::Equalizer()` method continues to work.

Also update specs to remove direct requires of `dry/core/equalizer`, since a require of `dry/core` alone should be sufficient to load Equalizer when it is used, given we use Zeitwerk.

## Remove all cherry-picked requires from specs and docs

While we're here, make the equivalent change of removing cherry-picked requires from all our other modules, both in specs and docs. These are no longer needed since we use Zeitwerk. A simple `require "dry/core"` alone is enough.