### PR TITLE
Add logger as a gemspec dependency

### DIFF
--- a/dry-core.gemspec
+++ b/dry-core.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   # to update dependencies edit project.yml
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_runtime_dependency "logger"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This prevents warnings about the upcoming removal of logger from the set of default gems:

```
lib/dry/core/deprecations.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5
```