### PR TITLE
Return false from BasicObject#respond_to_missing? (Fix for Ruby 4.0)

### DIFF
--- a/lib/dry/core/basic_object.rb
+++ b/lib/dry/core/basic_object.rb
@@ -127,12 +127,12 @@ module Dry
 
       private
 
-      # Must be overridden by descendants
+      # Can be overridden by descendants to customize respond_to? behavior
       #
       # @since 0.8.0
       # @api private
       def respond_to_missing?(_method_name, _include_all)
-        ::Kernel.raise ::NotImplementedError
+        false
       end
 
       # @since 0.8.0

--- a/spec/dry/core/basic_object_spec.rb
+++ b/spec/dry/core/basic_object_spec.rb
@@ -33,19 +33,19 @@ RSpec.describe Dry::Core::BasicObject do
   end
 
   describe "#respond_to_missing?" do
-    it "raises an exception if respond_to? method is not implemented" do
-      expect { TestClass.new.respond_to?(:no_existing_method) }
-        .to raise_error(NotImplementedError)
+    it "returns false for non-existing methods by default" do
+      expect(TestClass.new.respond_to?(:no_existing_method)).to be(false)
     end
 
-    it "returns true given respond_to? method was implemented" do
+    it "can be overridden to return true for custom methods" do
       TestCase = Class.new(TestClass) do
-        def respond_to?(_method_name, _include_all = false)
-          true
+        def respond_to_missing?(method_name, _include_all = false)
+          method_name == :custom_method || super
         end
       end
 
-      expect(TestCase.new).to respond_to(:no_existing_method)
+      expect(TestCase.new.respond_to?(:custom_method)).to be(true)
+      expect(TestCase.new.respond_to?(:no_existing_method)).to be(false)
     end
   end
 


### PR DESCRIPTION
Here's one approach to fix the failing tests on Ruby 4.0.0.

Return false from `BasicObject#respond_to_missing?`, rather than it raising a `NotImplementedError` by default.

This is to support changes to #inspect and #pretty_print in Ruby 4.0. Both of these methods now do a `respond_to?` check for `:instance_variables_to_inspect`, which require a working `respond_to_missing?`.

This change results in less surprising behaviour overall, given we already implement `#respond_to?` inside our BasicObject. In typical Ruby, a working `#respond_to_missing?` is expected to be found alongside each `#respnod_to?`.

cc @cllns (since I notice you have a slightly different approach pushed in a branch).